### PR TITLE
Email API Key Secret

### DIFF
--- a/lib/stacks/cloud-run.ts
+++ b/lib/stacks/cloud-run.ts
@@ -103,6 +103,10 @@ export class CloudRunStack extends BaseGCPStack {
           secretId: 'RAILS_ENCRYPTED_SECRETS',
           replication: {automatic: true},
         }),
+        new SecretWithVersion(this, 'email-api-key', {
+          secretId: 'LAYHOLD_EMAIL_SECRET',
+          replication: {automatic: true},
+        }),
       ],
       serviceAccount: this.serviceAccount,
       ports: [3000],


### PR DESCRIPTION
# Description

Adding in a var for the email provider api key. This will allow us to load that secret at runtime. This PR corresponds to changes in the rails app and the docker file seen here

https://github.com/layhold/rails-app/pull/13

## Notes

Have only tested locally, will update with any differences in infra if this does not work by pushing to this branch.